### PR TITLE
[BUGFIX] Enhance Test Option Handling: Fail on Non-Existent Files and Fix `js` Inclusion/Exclusion Error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kakasoo/deep-strict-types",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kakasoo/deep-strict-types",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "ISC",
       "dependencies": {
         "@kakasoo/proto-typescript": "^1.28.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kakasoo/deep-strict-types",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "typescript utility types including deep-strict-omit and pick type",
   "private": false,
   "publishConfig": {

--- a/test/helpers/TestFileLoader.ts
+++ b/test/helpers/TestFileLoader.ts
@@ -5,7 +5,7 @@ export namespace TestFileLoader {
   export type FilterOption = { exclude?: string[]; include?: string[] };
 
   const filter = (files: string[], options: FilterOption): string[] => {
-    return files.filter((file) => {
+    const filterFiles = files.filter((file) => {
       if (options.include) return isIncluded();
       if (options.exclude) return !isExcluded();
       return true;
@@ -18,6 +18,8 @@ export namespace TestFileLoader {
         return options.include?.some((incPath) => file.split(__dirname).at(0)?.includes(incPath));
       }
     });
+
+    return filterFiles;
   };
 
   const traverse = (dir: string, files: string[]) => {

--- a/test/helpers/TestFileLoader.ts
+++ b/test/helpers/TestFileLoader.ts
@@ -19,6 +19,10 @@ export namespace TestFileLoader {
       }
     });
 
+    if (options.include && filterFiles.length === 0) {
+      throw new Error(`No files matched the include option: ${options.include.join(', ')}`);
+    }
+
     return filterFiles;
   };
 

--- a/test/helpers/TestFileLoader.ts
+++ b/test/helpers/TestFileLoader.ts
@@ -11,11 +11,15 @@ export namespace TestFileLoader {
       return true;
 
       function isExcluded() {
-        return options.exclude?.some((exPath) => file.split(__dirname).at(0)?.replace(/\.js$/, '').includes(exPath));
+        return options.exclude?.some((exPath) => isMatched(exPath));
       }
 
       function isIncluded() {
-        return options.include?.some((incPath) => file.split(__dirname).at(0)?.replace(/\.js$/, '').includes(incPath));
+        return options.include?.some((incPath) => isMatched(incPath));
+      }
+
+      function isMatched(path: string): unknown {
+        return file.split(__dirname).at(0)?.replace(/\.js$/, '').includes(path);
       }
     });
 

--- a/test/helpers/TestFileLoader.ts
+++ b/test/helpers/TestFileLoader.ts
@@ -11,11 +11,11 @@ export namespace TestFileLoader {
       return true;
 
       function isExcluded() {
-        return options.exclude?.some((exPath) => file.split(__dirname).at(0)?.includes(exPath));
+        return options.exclude?.some((exPath) => file.split(__dirname).at(0)?.replace(/\.js$/, '').includes(exPath));
       }
 
       function isIncluded() {
-        return options.include?.some((incPath) => file.split(__dirname).at(0)?.includes(incPath));
+        return options.include?.some((incPath) => file.split(__dirname).at(0)?.replace(/\.js$/, '').includes(incPath));
       }
     });
 


### PR DESCRIPTION
## Description
This PR addresses issue #9 by adding logic to fail tests when a non-existent file is specified using the `--include` or `--exclude` options.

Additionally, it fixes an error where searching for "js" in the options results in all files being included or excluded.

## Changes

1. Updated TestFileLoader to throw errors for non-existent files.
2. Fixed the issue where searching for "js" in the options includes or excludes all files.

### Before

- Tests run and pass even if non-existent file names are specified.

```bash
$ npm run test -- --include non-existent

> @kakasoo/deep-strict-types@2.0.2 test
> node bin/test/index.js --include non-existent
```

-  Searching for "js" in the options results in all files being included or excluded.

```bash
$ npm run test -- --include js

> @kakasoo/deep-strict-types@2.0.2 test
> node bin/test/index.js --include js

... testing all files

ℹ tests 140
ℹ suites 24
ℹ pass 140
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 153.814736
```

```bash
$ npm run test -- --exclude js

> @kakasoo/deep-strict-types@2.0.2 test
> node bin/test/index.js --exclude js
```

### After

- Tests fail with proper error messages when non-existent file names are specified.
- Only specified files are included or excluded when searching for "js" in the options.

```bash
$ npm run test -- --include js

> @kakasoo/deep-strict-types@2.0.2 test
> node bin/test/index.js --include js

Error: No files matched the include option: js
    at filter (/home/user/DeepStrictTypes/bin/test/helpers/TestFileLoader.js:32:19)
    at TestFileLoader.load (/home/user/DeepStrictTypes/bin/test/helpers/TestFileLoader.js:63:16)
    at /home/user/DeepStrictTypes/bin/test/index.js:66:57
    at Generator.next (<anonymous>)
    at fulfilled (/home/user/DeepStrictTypes/bin/test/index.js:38:58)
```
