### PR TITLE
fix: support tuple types in DeepStrictObjectKeys

### DIFF
--- a/src/types/DeepStrictObjectKeys.ts
+++ b/src/types/DeepStrictObjectKeys.ts
@@ -6,6 +6,16 @@ import type { ValueType } from './ValueType';
 
 namespace DeepStrictObjectKeys {
   /**
+   * Distributive wrapper for Infer that properly handles union element types.
+   * When Element is a union (e.g., {a: 1} | {b: 2} from tuple [{ a: 1 }, { b: 2 }]),
+   * this distributes the Infer call to each member of the union individually,
+   * avoiding the issue where keyof (A | B) = (keyof A) & (keyof B) = never.
+   */
+  type DistributeInfer<T, Joiner extends { array: string; object: string }, IsSafe extends boolean> = T extends object
+    ? Infer<T, Joiner, IsSafe>
+    : never;
+
+  /**
    * Internal helper type that recursively extracts all keys from nested objects
    * @template Target - The object type to extract keys from
    * @template Joiner - Defines the symbols used to join nested paths (array: '[*]', object: '.')
@@ -34,7 +44,7 @@ namespace DeepStrictObjectKeys {
                               ? // For arrays of objects, add array notation and recurse into elements
                                 | P
                                   // | (Equal<IsSafe, true> extends true ? never : `${P}[*]`) // end of array
-                                  | `${P}${Joiner['array']}${Joiner['object']}${Infer<_Element, Joiner, IsSafe>}` // recursive
+                                  | `${P}${Joiner['array']}${Joiner['object']}${DistributeInfer<_Element, Joiner, IsSafe>}` // recursive
                               : // For regular objects, add object notation and recurse
                                 `${P}${Joiner['object']}${Infer<E, Joiner, IsSafe>}` // recursive
                             : never // Remove all primitive types of union types.
@@ -43,7 +53,7 @@ namespace DeepStrictObjectKeys {
                 ? // Handle arrays containing objects
                   | P
                     // | (Equal<IsSafe, true> extends true ? never : `${P}[*]`) // end of array
-                    | `${P}${Joiner['array']}${Joiner['object']}${Infer<Element, Joiner, false>}`
+                    | `${P}${Joiner['array']}${Joiner['object']}${DistributeInfer<Element, Joiner, false>}`
                 : Target[P] extends Array<infer _Element>
                   ? // Handle arrays containing primitives
                     Equal<IsSafe, true> extends true

--- a/test/features/DeepStrictObjectKeys.ts
+++ b/test/features/DeepStrictObjectKeys.ts
@@ -966,3 +966,88 @@ export function test_types_deep_strict_object_keys_glob_deep_nested() {
   type Answer = Equal<'a.b.*' extends Keys ? true : false, true>;
   ok(typia.random<Answer>());
 }
+
+/**
+ * Tests that DeepStrictObjectKeys returns never for an empty tuple.
+ */
+export function test_types_deep_strict_object_keys_empty_tuple() {
+  type Question = DeepStrictObjectKeys<[]>;
+  type Answer = Equal<Question, never>;
+  ok(typia.random<Answer>());
+}
+
+/**
+ * Tests that DeepStrictObjectKeys returns '[*]' for a single-element primitive tuple.
+ */
+export function test_types_deep_strict_object_keys_primitive_tuple() {
+  type Question = DeepStrictObjectKeys<['a']>;
+  type Answer = Equal<Question, '[*]'>;
+  ok(typia.random<Answer>());
+}
+
+/**
+ * Tests that DeepStrictObjectKeys returns '[*]' for a multi-element primitive tuple.
+ */
+export function test_types_deep_strict_object_keys_multi_primitive_tuple() {
+  type Question = DeepStrictObjectKeys<[string, number]>;
+  type Answer = Equal<Question, '[*]'>;
+  ok(typia.random<Answer>());
+}
+
+/**
+ * Tests that DeepStrictObjectKeys returns '[*]' for a readonly primitive tuple.
+ */
+export function test_types_deep_strict_object_keys_readonly_primitive_tuple() {
+  type Question = DeepStrictObjectKeys<readonly ['a']>;
+  type Answer = Equal<Question, '[*]'>;
+  ok(typia.random<Answer>());
+}
+
+/**
+ * Tests that DeepStrictObjectKeys returns correct keys for a tuple of objects
+ * with the same shape.
+ */
+export function test_types_deep_strict_object_keys_same_shape_object_tuple() {
+  type Question = DeepStrictObjectKeys<[{ a: 1 }, { a: 2 }]>;
+  type Answer = Equal<Question, '[*]' | '[*].a' | '[*].*'>;
+  ok(typia.random<Answer>());
+}
+
+/**
+ * Tests that DeepStrictObjectKeys returns correct keys for a heterogeneous tuple
+ * where elements have different shapes.
+ */
+export function test_types_deep_strict_object_keys_heterogeneous_object_tuple() {
+  type Question = DeepStrictObjectKeys<[{ a: 1 }, { b: 2 }]>;
+  type Answer = Equal<Question, '[*]' | '[*].a' | '[*].b' | '[*].*'>;
+  ok(typia.random<Answer>());
+}
+
+/**
+ * Tests that DeepStrictObjectKeys correctly recurses into nested tuple elements
+ * when the tuple is a property of an object.
+ */
+export function test_types_deep_strict_object_keys_nested_heterogeneous_tuple() {
+  type Question = DeepStrictObjectKeys<{ items: [{ a: 1 }, { b: 2 }] }>;
+  type Answer = Equal<Question, '*' | 'items' | 'items[*].a' | 'items[*].b' | 'items[*].*'>;
+  ok(typia.random<Answer>());
+}
+
+/**
+ * Tests that DeepStrictObjectKeys handles a nested same-shape object tuple.
+ */
+export function test_types_deep_strict_object_keys_nested_same_shape_tuple() {
+  type Question = DeepStrictObjectKeys<{ items: [{ a: 1 }, { a: 2 }] }>;
+  type Answer = Equal<Question, '*' | 'items' | 'items[*].a' | 'items[*].*'>;
+  ok(typia.random<Answer>());
+}
+
+/**
+ * Tests that DeepStrictObjectKeys handles a nested primitive tuple
+ * (no deeper recursion needed).
+ */
+export function test_types_deep_strict_object_keys_nested_primitive_tuple() {
+  type Question = DeepStrictObjectKeys<{ items: [string, number] }>;
+  type Answer = Equal<Question, '*' | 'items'>;
+  ok(typia.random<Answer>());
+}


### PR DESCRIPTION
## Summary
- Fixed `DeepStrictObjectKeys` to properly handle heterogeneous tuple types (e.g., `[{ a: 1 }, { b: 2 }]`) by adding a `DistributeInfer` wrapper that distributes over union element types
- Previously, nested keys were lost because `keyof (A | B)` resolves to `never` when A and B share no common keys
- Added 9 comprehensive tuple test cases covering empty, primitive, readonly, same-shape, and heterogeneous tuples

Closes #6

## Test plan
- [x] `npm run build:test && npm run test` — all 338 tests pass (329 existing + 9 new)
- [x] `npm run prettier` — formatting applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)