### PR TITLE
fix: correct grammar in error message

### DIFF
--- a/src/functions/DeepStrictAssert.ts
+++ b/src/functions/DeepStrictAssert.ts
@@ -52,7 +52,7 @@ export const deepStrictAssert =
           return { [first]: input[first] };
         }
 
-        throw new Error(`input doesn\'t has key: ${first}`);
+        throw new Error(`input doesn\'t have key: ${first}`);
       }
     };
 


### PR DESCRIPTION
## Summary
- Corrects a grammar error in `deepStrictAssert` error message
- Changes "doesn't has" to "doesn't have"

## Test Plan
- All 376 tests pass
- No functional changes, only error message improvement

Closes #18