### PR TITLE
docs: add missing core types and functions to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,12 +51,20 @@ test/
 | 타입 | 역할 |
 |------|------|
 | `DeepStrictObjectKeys<T>` | 중첩 객체의 모든 키를 dot notation으로 추출 (`a.b`, `c[*].d`) |
-| `DeepStrictOmit<T, K>` | 중첩 키를 기준으로 deep omit |
-| `DeepStrictPick<T, K>` | 중첩 키를 기준으로 deep pick |
+| `DeepStrictOmit<T, K>` | 중첩 키를 기준으로 deep omit (존재하지 않는 키 사용 시 컴파일 에러) |
+| `DeepStrictPick<T, K>` | 중첩 키를 기준으로 deep pick (존재하지 않는 키 사용 시 컴파일 에러) |
 | `DeepStrictMerge<T, U>` | 두 객체를 deep merge |
+| `DeepOmit<T, K>` | 중첩 키를 기준으로 deep omit (non-strict, 잘못된 키 무시) |
+| `DeepPick<T, K>` | 중첩 키를 기준으로 deep pick (non-strict, 잘못된 키 무시) |
+| `DeepMerge<T, U>` | 두 객체를 deep merge (source wins, spread 패턴) |
 | `DeepDateToString<T>` | Date 타입을 string으로 재귀 변환 |
 | `DeepStrictUnbrand<T>` | 브랜드 타입 제거 |
+| `GetType<T, K>` | 중첩 경로의 타입 추출 (`GetType<{a: {b: 1}}, "a.b">` → `1`) |
+| `StringToDeepObject<T>` | 콤마 구분 dot 표기법 → 중첩 객체 타입 변환 |
+| `ElementOf<T>` | 배열 요소 타입 추출 |
 | `Equal<A, B>` | 두 타입의 동등성 검사 (테스트용) |
+| `IsAny<T>` | any 타입 체크 |
+| `IsUnion<T>` | 유니온 타입 체크 |
 
 ### 핵심 함수
 
@@ -64,6 +72,7 @@ test/
 |------|------|
 | `deepStrictAssert<T>(input)<K>(key)` | 런타임에서 특정 키만 추출 (타입 안전) |
 | `deepStrictObjectKeys<T>(input)` | 런타임에서 모든 중첩 키 문자열 배열 반환 |
+| `deepStrictPick<T>(input)<K>(keys)` | 런타임에서 중첩 키 기준으로 pick (타입 안전) |
 
 ## Coding Conventions
 


### PR DESCRIPTION
## Summary
- CLAUDE.md 핵심 타입 테이블에 누락된 core 타입 8개 추가 (`DeepOmit`, `DeepPick`, `DeepMerge`, `GetType`, `StringToDeepObject`, `ElementOf`, `IsAny`, `IsUnion`)
- 핵심 함수 테이블에 `deepStrictPick` 추가
- 기존 `DeepStrictOmit`, `DeepStrictPick` 설명에 strict 특성 명시

Closes #23

### 이슈 검토 결과
이슈는 **부분적으로 타당**합니다:
- **타당한 부분**: 핵심 core 타입과 함수가 테이블에서 누락되어 있었음
- **타당하지 않은 부분**: 내부 헬퍼 타입(`GetMember`, `RemoveAfterDot`, `RemoveLastProperty`, `RemoveArraySymbol`, `ExpandGlob`, `ValueType`, `DeepStrictObjectLastKeys`)까지 핵심 타입 테이블에 넣으면 가독성이 오히려 저하됨. 이들은 JSDoc에서 `@internal` 또는 `helper` 로 명시됨
- **부정확한 정보**: `GetElementMember`은 독립 export가 아니라 namespace 내부 멤버. 실제 export 수도 타입 23개/함수 3개 (이슈는 19/2로 기재)

## Test plan
- [x] `npm run build:test && npm run test` — 376개 테스트 전체 통과 (문서 변경만이므로 빌드에 영향 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)