### PR TITLE
fix: add rest.length > 0 guard to deepStrictAssert

### DIFF
--- a/src/functions/DeepStrictAssert.ts
+++ b/src/functions/DeepStrictAssert.ts
@@ -33,7 +33,7 @@ export const deepStrictAssert =
       if (input instanceof Array) {
         const elements = input.map((element) => {
           if (first in element) {
-            if (typeof element[first] === 'object' && element[first] !== null) {
+            if (typeof element[first] === 'object' && element[first] !== null && rest.length > 0) {
               return { [first]: traverse(element[first], rest) };
             }
 
@@ -46,7 +46,7 @@ export const deepStrictAssert =
         return elements;
       } else {
         if (first in input) {
-          if (typeof input[first] === 'object' && input[first] !== null) {
+          if (typeof input[first] === 'object' && input[first] !== null && rest.length > 0) {
             return { [first]: traverse(input[first], rest) };
           }
           return { [first]: input[first] };

--- a/test/features/DeepStrictAssert.ts
+++ b/test/features/DeepStrictAssert.ts
@@ -106,6 +106,14 @@ export function test_functions_deepStrictAssert_accesses_nested_object_property(
 }
 
 /**
+ * Tests that deepStrictAssert can access a top-level key whose value is a plain object.
+ */
+export function test_functions_deepStrictAssert_accesses_top_level_object_property() {
+  const original = typia.random<SimpleNested>();
+  typia.assertEquals(deepStrictAssert(original)('user'));
+}
+
+/**
  * Tests that deepStrictAssert throws when accessing a non-existent key.
  */
 export function test_functions_deepStrictAssert_throws_on_invalid_key() {


### PR DESCRIPTION
## Summary
- Add missing `rest.length > 0` guard to `deepStrictAssert` to prevent runtime error when picking top-level keys whose values are plain objects
- Matches the fix already present in `deepStrictPick`
- Add test case for top-level object property access

## Test plan
- All 380 existing tests pass
- New test `test_functions_deepStrictAssert_accesses_top_level_object_property` verifies the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)