### PR TITLE
fix: prevent deepStrictAssert crash on non-leaf object keys

### DIFF
--- a/src/functions/DeepStrictAssert.ts
+++ b/src/functions/DeepStrictAssert.ts
@@ -33,7 +33,7 @@ export const deepStrictAssert =
       if (input instanceof Array) {
         const elements = input.map((element) => {
           if (first in element) {
-            if (typeof element[first] === 'object' && element[first] !== null) {
+            if (typeof element[first] === 'object' && element[first] !== null && rest.length > 0) {
               return { [first]: traverse(element[first], rest) };
             }
 
@@ -46,7 +46,7 @@ export const deepStrictAssert =
         return elements;
       } else {
         if (first in input) {
-          if (typeof input[first] === 'object' && input[first] !== null) {
+          if (typeof input[first] === 'object' && input[first] !== null && rest.length > 0) {
             return { [first]: traverse(input[first], rest) };
           }
           return { [first]: input[first] };

--- a/test/features/DeepStrictAssert.ts
+++ b/test/features/DeepStrictAssert.ts
@@ -1,3 +1,4 @@
+import { ok } from 'assert';
 import typia, { tags } from 'typia';
 import { deepStrictAssert } from '../../src';
 
@@ -129,4 +130,15 @@ export function test_functions_deepStrictAssert_accesses_multiple_nested_array_p
   const resultE = deepStrictAssert(original)('c[*].e');
   typia.assertEquals(resultD);
   typia.assertEquals(resultE);
+}
+
+/**
+ * Tests that deepStrictAssert can access a non-leaf object key without crashing.
+ * This verifies the fix for GitHub issue #19.
+ */
+export function test_functions_deepStrictAssert_accesses_non_leaf_object_key() {
+  const data = { user: { name: 'Alice', age: 30 } };
+  const result = deepStrictAssert(data)('user');
+  ok(result.user.name === 'Alice');
+  ok(result.user.age === 30);
 }


### PR DESCRIPTION
## Summary

Fix a crash in `deepStrictAssert` when accessing non-leaf object keys (e.g., `'user'` in a deeply nested structure). Added `rest.length > 0` guard before recursing into nested objects, consistent with the existing fix in `deepStrictPick`.

Closes #19

## Changes

- Add guard condition to prevent recursive traversal with empty `keys` array
- Add regression test for non-leaf object key access

## Test Status

All 380 tests passing, including new test for non-leaf object key access.