### PR TITLE
fix: correct grammar in deepStrictPick error message

### DIFF
--- a/src/functions/DeepStrictPick.ts
+++ b/src/functions/DeepStrictPick.ts
@@ -52,7 +52,7 @@ export const deepStrictPick = <T extends object, K extends DeepStrictObjectKeys<
         return { [first]: input[first] };
       }
 
-      throw new Error(`input doesn\'t has key: ${first}`);
+      throw new Error(`input doesn\'t have key: ${first}`);
     }
   };
 


### PR DESCRIPTION
## Summary
Corrects the grammar in the error message thrown by `deepStrictPick` when an invalid key is accessed.

**Change:** `input doesn't has key` → `input doesn't have key`

## Files Changed
- `src/functions/DeepStrictPick.ts` (line 55)

## Testing
All 27 deepStrictPick tests pass successfully.

🤖 Generated with Claude Code