### PR TITLE
style: use `import type` for type-only imports across src

### DIFF
--- a/src/functions/DeepStrictAssert.ts
+++ b/src/functions/DeepStrictAssert.ts
@@ -1,5 +1,5 @@
-import { DeepStrictObjectKeys } from '../types/DeepStrictObjectKeys';
-import { DeepStrictPick } from '../types/DeepStrictPick';
+import type { DeepStrictObjectKeys } from '../types/DeepStrictObjectKeys';
+import type { DeepStrictPick } from '../types/DeepStrictPick';
 
 /**
  * @title Runtime Function for Type-Safe Deep Property Extraction.

--- a/src/functions/DeepStrictObjectKeys.ts
+++ b/src/functions/DeepStrictObjectKeys.ts
@@ -1,4 +1,4 @@
-import { DeepStrictObjectKeys } from '../types';
+import type { DeepStrictObjectKeys } from '../types';
 
 /** @internal Removes a leading dot from a string type. e.g., `".foo"` becomes `"foo"`. */
 type RemoveStartWithDot<T extends string> = T extends `.${infer R extends string}` ? R : T;

--- a/src/functions/DeepStrictPick.ts
+++ b/src/functions/DeepStrictPick.ts
@@ -1,5 +1,5 @@
-import { DeepStrictObjectKeys } from '../types/DeepStrictObjectKeys';
-import { DeepStrictPick } from '../types/DeepStrictPick';
+import type { DeepStrictObjectKeys } from '../types/DeepStrictObjectKeys';
+import type { DeepStrictPick } from '../types/DeepStrictPick';
 
 /**
  * @title Runtime Function for Type-Safe Deep Property Picking.

--- a/src/types/DeepDateToString.ts
+++ b/src/types/DeepDateToString.ts
@@ -1,4 +1,4 @@
-import { DeepStrictUnbrand } from './DeepStrictUnbrand';
+import type { DeepStrictUnbrand } from './DeepStrictUnbrand';
 
 /**
  * @title Type for Recursively Converting All Date Types to String.

--- a/src/types/DeepStrictObjectKeys.ts
+++ b/src/types/DeepStrictObjectKeys.ts
@@ -1,5 +1,5 @@
-import { DeepStrictUnbrand } from './DeepStrictUnbrand';
-import { Equal } from './Equal';
+import type { DeepStrictUnbrand } from './DeepStrictUnbrand';
+import type { Equal } from './Equal';
 import type { IsAny } from './IsAny';
 import type { IsUnion } from './IsUnion';
 import type { ValueType } from './ValueType';

--- a/src/types/DeepStrictObjectLastKeys.ts
+++ b/src/types/DeepStrictObjectLastKeys.ts
@@ -1,4 +1,4 @@
-import { DeepStrictUnbrand } from './DeepStrictUnbrand';
+import type { DeepStrictUnbrand } from './DeepStrictUnbrand';
 import type { IsAny } from './IsAny';
 import type { IsUnion } from './IsUnion';
 import type { ValueType } from './ValueType';

--- a/src/types/RemoveAfterDot.ts
+++ b/src/types/RemoveAfterDot.ts
@@ -1,4 +1,4 @@
-import { ElementOf } from './ElementOf';
+import type { ElementOf } from './ElementOf';
 
 /**
  * @title Type for Generating Wildcard Patterns for Descendant Keys.

--- a/src/types/StringToDeepObject.ts
+++ b/src/types/StringToDeepObject.ts
@@ -1,4 +1,4 @@
-import { StringType } from '@kakasoo/proto-typescript';
+import type { StringType } from '@kakasoo/proto-typescript';
 
 /** @internal Converts a union type to an intersection type. */
 type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void ? I : never;


### PR DESCRIPTION
## Summary

Fixed CLAUDE.md coding convention: "타입 간 의존성은 import type 사용" (use `import type` for type-only imports).

Applied to 8 files in `src/`:
- 5 files in `src/types/` (DeepDateToString, DeepStrictObjectKeys, DeepStrictObjectLastKeys, RemoveAfterDot, StringToDeepObject)
- 3 files in `src/functions/` (DeepStrictAssert, DeepStrictObjectKeys, DeepStrictPick)

This improves tree-shaking and clarifies type-only dependencies per TypeScript best practices.

## Verification

All 385 tests pass, no build issues, prettier format unchanged.

🤖 Generated with Claude Code